### PR TITLE
Inherited from XUnit.Assert

### DIFF
--- a/NHamcrest.XUnit.Examples/AssertExTests.cs
+++ b/NHamcrest.XUnit.Examples/AssertExTests.cs
@@ -9,19 +9,19 @@ namespace NHamcrest.XUnit.Examples
         [Fact]
         public void Pass()
         {
-            AssertEx.That(1, Is.EqualTo(1));
+            Assert.That(1, Is.EqualTo(1));
         }
 
         [Fact]
         public void Fail()
         {
-            AssertEx.That(1, Is.EqualTo(3));
+            Assert.That(1, Is.EqualTo(3));
         }
 
         [Fact]
         public void One_more()
         {
-            AssertEx.That(() => { throw new InvalidOperationException(); }, Throws.An<AccessViolationException>());
+            Assert.That(() => { throw new InvalidOperationException(); }, Throws.An<AccessViolationException>());
         }
     }
 }

--- a/NHamcrest.XUnit/AssertEx.cs
+++ b/NHamcrest.XUnit/AssertEx.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace NHamcrest.XUnit
+﻿namespace NHamcrest.XUnit
 {
-    public class AssertEx
+    public class Assert : Xunit.Assert
     {
         public static void That<T>(T actual, IMatcher<T> matcher)
         {


### PR DESCRIPTION
Hi Graham!

Since XUnit.Assert is a non-sealed type I renamed the NHamcrest.XUnit.AssertEx class to NHamcrest.XUnit.Assert and then inherited from Xunit.Assert class. 

That way, we have all the functionality that XUnit can offer plus the NHarmcrest features all using one type (NHamcrest.XUnit.Assert).
