### PR TITLE
Building For CoreCLR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@
 _ReSharper*
 bin
 obj
+
+.DS_Store
+
+artifacts
+
+*/project.lock.json
+
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/NHamcrest.NUnit/AssertEx.cs
+++ b/NHamcrest.NUnit/AssertEx.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using NUnit.Framework;
-
+using NUnit.Framework.Internal;
 namespace NHamcrest.NUnit
 {
     public class AssertEx

--- a/NHamcrest.NUnit/project.json
+++ b/NHamcrest.NUnit/project.json
@@ -1,0 +1,43 @@
+{
+  "version": "1.3.0-*",
+  "buildOptions": {
+    "emitEntryPoint": false,
+    "compilerName":"csc",
+    "compile": [
+      "./**/*.cs" 
+    ]
+  },
+  "dependencies": {
+    "NHamcrest": {
+      "version":"1.3.0-*",
+      "type":"build"
+    },
+    "NUnit":"3.2.0"
+  },
+  "frameworks": {
+    "net20": {
+      "dependencies": {
+        "xunit":"1.9.2"
+      }
+    },
+    "net451": {
+      "frameworkAssemblies":{
+        "System.Runtime":""
+      },
+      "imports": [
+        "portable-net451+win81+wp81"
+      ]
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-3002702"
+        }
+      },
+      "imports": [
+        "portable-net451+win81+wp81"
+      ]
+    }
+  }
+}

--- a/NHamcrest.Tests/project.json
+++ b/NHamcrest.Tests/project.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.3.0-*",
+  "buildOptions": {
+    "emitEntryPoint": false,
+    "compilerName":"csc",
+    "compile": [
+      "./**/*.cs" 
+    ]
+  },
+  "dependencies": {
+    "NHamcrest": {
+      "version":"1.3.0-*",
+      "type":"build"
+    },
+    "mbunit":"3.4.14",
+    "RhinoMocks":"3.6.1"
+  },
+  "frameworks": {
+    "net451": {
+      "imports": [
+        "portable-net451+win81+wp81"
+      ]
+    },
+  }
+}

--- a/NHamcrest.XUnit/project.json
+++ b/NHamcrest.XUnit/project.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.3.0-*",
+  "buildOptions": {
+    "emitEntryPoint": false,
+    "compilerName":"csc",
+    "compile": [
+      "./**/*.cs" 
+    ]
+  },
+  "dependencies": {
+    "NHamcrest": {
+      "version":"1.3.0-*",
+      "type":"build"
+    }
+  },
+  "frameworks": {
+    "net20": {
+      "dependencies": {
+        "xunit":"1.9.2"
+      }
+    },
+    "net451": {
+      "frameworkAssemblies":{
+        "System.Runtime":""
+      },
+      "dependencies": {
+        "xunit":"2.1.0",
+      },
+      "imports": [
+        "portable-net451+win81+wp81"
+      ]
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "xunit":"2.1.0",
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-3002702"
+        }
+      },
+      "imports": [
+        "portable-net451+win81+wp81"
+      ]
+    }
+  }
+}

--- a/NHamcrest/Core/IsInstanceOf.cs
+++ b/NHamcrest/Core/IsInstanceOf.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace NHamcrest.Core
 {

--- a/NHamcrest/project.json
+++ b/NHamcrest/project.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.3.0-*",
+  "buildOptions": {
+    "emitEntryPoint": false,
+    "compilerName":"csc",
+    "compile": [
+      "./**/*.cs" 
+    ]
+  },
+  "frameworks": {
+    "net20": {
+      "frameworkAssemblies":{
+        "System":"",
+        "System.Xml":"",
+        "System.Data":""
+      },
+    },
+    "net451": {
+      "frameworkAssemblies": {
+        "System":"",
+        "System.Xml":"",
+        "System.Data":""
+      },
+      "imports": [
+        "portable-net451+win8+wp8+wpa8"
+      ]
+    },
+    "netcoreapp1.0": {
+      "imports": [
+        "portable-net451+win8+wp8+wpa8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-3002702"
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 NHamcrest
 =============
 
+[![Build status](https://ci.appveyor.com/api/projects/status/c7nii8j77oa7tn89?svg=true)](https://ci.appveyor.com/project/lynxluna/nhamcrest)
+
 This is an idiomatic C# port of [Hamcrest](http://code.google.com/p/hamcrest/), specifically the Java version.

--- a/Scripts/show-dotnet-info.ps1
+++ b/Scripts/show-dotnet-info.ps1
@@ -1,0 +1,7 @@
+if (Get-Command dotnet -errorAction SilentlyContinue) {
+  Write-Host "Using dotnet '$((Get-Command dotnet).Path)'"
+  dotnet --version
+}
+else {
+  Write-Host "dotnet.exe not found"
+}

--- a/Scripts/show-dotnet-info.sh
+++ b/Scripts/show-dotnet-info.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+which dotnet
+if test $? -eq 0; then
+  echo "Using dotnet:"
+  dotnet --version
+else
+  echo "dotnet not found"
+fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+version: 1.3.0-b{build}
+platform: Any CPU
+
+environment:
+  matrix:
+    - CLI_VERSION: Latest
+
+init:
+  - ps: $env:PADDED_BUILD_NUMBER = ([int]$env:APPVEYOR_BUILD_NUMBER).toString("0000000")  
+ 
+install:
+  - ps: .\scripts\show-dotnet-info.ps1
+  # Download install script to install .NET cli in .dotnet dir
+  - ps: mkdir -Force ".\scripts\obtain" | Out-Null
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\scripts\obtain\install.ps1"
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
+  - ps: '& .\scripts\obtain\install.ps1 -Channel "preview" -version "$env:CLI_VERSION" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath'
+  # add dotnet to PATH
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+
+build_script:
+  - ps: .\scripts\show-dotnet-info.ps1
+  - ps: dotnet --info
+  - ps: dotnet restore
+  - ps: dotnet build NHamcrest NHamcrest.NUnit NHamcrest.XUnit NHamcrest.Tests
+  - ps: dotnet pack --version-suffix "b$env:PADDED_BUILD_NUMBER" -c Release NHamcrest -o artifacts 
+  - ps: dotnet pack --version-suffix "b$env:PADDED_BUILD_NUMBER" -c Release NHamcrest.NUnit -o artifacts
+  - ps: dotnet pack --version-suffix "b$env:PADDED_BUILD_NUMBER" -c Release NHamcrest.XUnit -o artifacts
+
+
+test:
+  assemblies:
+    - NHamcrest.Tests.dll
+
+artifacts:
+  - path: artifacts/*.nupkg
+
+deploy:
+  provider: NuGet
+  server: https://www.myget.org/F/nhamcrest/api/v2/package
+  api_key:
+    secure: b5oBmcZl3AXKVJ/lzr6SFRUqgUXK8V8rGmFTiIFp70UMZmuOzyJa6x/l0UTIaElq
+  skip_symbols: false
+  symbol_server: https://www.myget.org/F/nhamcrest/api/v2/package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ init:
   - ps: $env:PADDED_BUILD_NUMBER = ([int]$env:APPVEYOR_BUILD_NUMBER).toString("0000000")  
  
 install:
-  - ps: .\scripts\show-dotnet-info.ps1
+  - ps: .\Scripts\show-dotnet-info.ps1
   # Download install script to install .NET cli in .dotnet dir
   - ps: mkdir -Force ".\scripts\obtain" | Out-Null
   - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\scripts\obtain\install.ps1"
@@ -20,12 +20,12 @@ install:
 
 build_script:
   - ps: .\scripts\show-dotnet-info.ps1
-  - ps: dotnet --info
-  - ps: dotnet restore
-  - ps: dotnet build NHamcrest NHamcrest.NUnit NHamcrest.XUnit NHamcrest.Tests
-  - ps: dotnet pack --version-suffix "b$env:PADDED_BUILD_NUMBER" -c Release NHamcrest -o artifacts 
-  - ps: dotnet pack --version-suffix "b$env:PADDED_BUILD_NUMBER" -c Release NHamcrest.NUnit -o artifacts
-  - ps: dotnet pack --version-suffix "b$env:PADDED_BUILD_NUMBER" -c Release NHamcrest.XUnit -o artifacts
+  - dotnet --info
+  - dotnet restore
+  - dotnet build NHamcrest NHamcrest.NUnit NHamcrest.XUnit NHamcrest.Tests
+  - dotnet pack --version-suffix "b%PADDED_BUILD_NUMBER%" -c Release NHamcrest -o artifacts 
+  - dotnet pack --version-suffix "b%PADDED_BUILD_NUMBER%" -c Release NHamcrest.NUnit -o artifacts
+  - dotnet pack --version-suffix "b%PADDED_BUILD_NUMBER%" -c Release NHamcrest.XUnit -o artifacts
 
 
 test:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "projects": [
+    "NHamcrest",
+    "NHamcrest.XUnit",
+    "NHamcrest.NUnit",
+    "NHamcrest.Tests"
+  ]
+}


### PR DESCRIPTION
Maintain compatibility with .NET 2.0, .NET 4.5.x, and CoreCLR.
- Using project json and dotnet/cli
- For .NET 2.0 depends on XUnit 1.9.2, .NET > 4.5.x use XUnit 2.1.0
- Automatic build using AppVeyor
- Upload Artifacts to MyGet

I also increase the minor version number to `1.3.0`

Please let me know if you have any concern.

The CI is over here: https://ci.appveyor.com/project/lynxluna/nhamcrest
My MyGet Feed is here: https://www.myget.org/feed/Packages/nhamcrest
