### PR TITLE
Assert.That and Is()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        dotnet: [7.0.100]
+        dotnet: [7.0.302]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/src/NHamcrest.NUnit.Examples/NHamcrest.NUnit.Examples.csproj
+++ b/src/NHamcrest.NUnit.Examples/NHamcrest.NUnit.Examples.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NHamcrest.NUnit\NHamcrest.NUnit.csproj" />

--- a/src/NHamcrest.NUnit/AssertEx.cs
+++ b/src/NHamcrest.NUnit/AssertEx.cs
@@ -46,7 +46,7 @@ namespace NHamcrest.NUnit
         {
             if (matcher.Matches(actual))
                 return;
-            
+
             var writer = new TextMessageWriter(message, args);
 
             WriteExpected(matcher, writer);
@@ -67,7 +67,7 @@ namespace NHamcrest.NUnit
 
         private static void WriteActual<T>(T actual, IMatcher<T> matcher, TextWriter writer)
         {
-            writer.Write("  But ");
+            writer.Write(TextMessageWriter.Pfx_Actual);
             var mismatchDescription = new StringDescription();
             matcher.DescribeMismatch(actual, mismatchDescription);
             writer.Write(mismatchDescription.ToString());

--- a/src/NHamcrest.NUnit/NHamcrest.NUnit.csproj
+++ b/src/NHamcrest.NUnit/NHamcrest.NUnit.csproj
@@ -4,18 +4,16 @@
     <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Copyright>Copyright © 2022</Copyright>
-    <Version Condition="'$(VersionSuffix)' == ''">3.1.0</Version>
-    <Version Condition="'$(VersionSuffix)' != ''">3.1.0-$(VersionSuffix)</Version>
+    <Copyright>Copyright © 2023</Copyright>
+    <Version Condition="'$(VersionSuffix)' == ''">3.2.0</Version>
+    <Version Condition="'$(VersionSuffix)' != ''">3.2.0-$(VersionSuffix)</Version>
     <Description>Adapter for NUnit for using NHamcrest library</Description>
-    <Authors>Graham Hay, Algirdas Lašas</Authors>
-    <Company />
-    <Product />
+    <Authors>Graham Hay, Algirdas Lašas, Constantin Tews</Authors>
     <PackageLicenseUrl>https://github.com/nhamcrest/NHamcrest/blob/master/LICENCE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/nhamcrest/NHamcrest</PackageProjectUrl>
     <PackageTags>unittesting hamcrest matcher test</PackageTags>
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
-    <FileVersion>3.1.0.0</FileVersion>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/NHamcrest.Tests/Core/IsEqualTests.cs
+++ b/src/NHamcrest.Tests/Core/IsEqualTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using NHAssert = NHamcrest.Tests.Internal.Assert;
@@ -43,7 +42,7 @@ namespace NHamcrest.Tests.Core
 
             isEqual.DescribeTo(description);
 
-            Assert.Equal("\"" + test + "\"", description.ToString());
+            Assert.Equal($"\"{test}\"", description.ToString());
         }
     }
 }

--- a/src/NHamcrest.Tests/Core/IsExtensionsTests.cs
+++ b/src/NHamcrest.Tests/Core/IsExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿using Xunit;
+using NHAssert = NHamcrest.Tests.Internal.Assert;
+using static NHamcrest.Extensions.IsExtensions;
+
+namespace NHamcrest.Tests.Core
+{
+    public class IsExtensionsTests
+    {
+        [Fact]
+        public void Match_if_bool_is_equal_with_IsExtension()
+        {
+            NHAssert.That(true, Is(true));
+        }
+
+        [Fact]
+        public void Match_if_string_is_equal_with_IsExtension()
+        {
+            NHAssert.That("test", Is("test"));
+        }
+
+        [Fact]
+        public void Match_if_int_is_equal_with_IsExtension()
+        {
+            NHAssert.That(1, Is(1));
+        }
+
+        [Fact]
+        public void Match_if_decimal_is_equal_with_IsExtension()
+        {
+            NHAssert.That(1m, Is(1m));
+        }
+    }
+}

--- a/src/NHamcrest.Tests/NHamcrest.Tests.csproj
+++ b/src/NHamcrest.Tests/NHamcrest.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Description />
   </PropertyGroup>
   <ItemGroup>
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Castle.Core" Version="5.1.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Microsoft.NET.TEST.Sdk" Version="17.4.0" />
+    <PackageReference Include="Castle.Core" Version="5.1.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NET.TEST.Sdk" Version="17.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NHamcrest.XUnit\NHamcrest.XUnit.csproj" />

--- a/src/NHamcrest.XUnit.Examples/NHamcrest.XUnit.Examples.csproj
+++ b/src/NHamcrest.XUnit.Examples/NHamcrest.XUnit.Examples.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>

--- a/src/NHamcrest.XUnit/AssertEx.cs
+++ b/src/NHamcrest.XUnit/AssertEx.cs
@@ -16,6 +16,32 @@ namespace NHamcrest.XUnit
         /// <exception cref="MatchException"></exception>
         public static void That<T>(T actual, IMatcher<T> matcher)
         {
+            That(actual, matcher, null);
+        }
+
+        /// <summary>
+        /// Checks if actual matches in IMatcher.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="actual"></param>
+        /// <param name="matcher"></param>
+        /// <param name="message"></param>
+        public static void That<T>(T actual, IMatcher<T> matcher, string message)
+        {
+            That(actual, matcher, message, null);
+        }
+
+        /// <summary>
+        /// Checks if actual matches in IMatcher.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="actual"></param>
+        /// <param name="matcher"></param>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        /// <exception cref="MatchException"></exception>
+        public static void That<T>(T actual, IMatcher<T> matcher, string message, params object[] args)
+        {
             if (matcher.Matches(actual))
                 return;
 
@@ -25,7 +51,11 @@ namespace NHamcrest.XUnit
             var mismatchDescription = new StringDescription();
             matcher.DescribeMismatch(actual, mismatchDescription);
 
-            throw new MatchException(description.ToString(), mismatchDescription.ToString(), null);
+            string userMessage = args != null && args.Length > 0 
+                ? string.Format(message, args)
+                : message;
+
+            throw new MatchException(description.ToString(), mismatchDescription.ToString(), userMessage);
         }
     }
 }

--- a/src/NHamcrest.XUnit/NHamcrest.XUnit.csproj
+++ b/src/NHamcrest.XUnit/NHamcrest.XUnit.csproj
@@ -4,16 +4,16 @@
     <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Copyright>Copyright © 2022</Copyright>
-    <Version Condition="'$(VersionSuffix)' == ''">3.1.0</Version>
-    <Version Condition="'$(VersionSuffix)' != ''">3.1.0-$(VersionSuffix)</Version>
+    <Copyright>Copyright © 2023</Copyright>
+    <Version Condition="'$(VersionSuffix)' == ''">3.2.0</Version>
+    <Version Condition="'$(VersionSuffix)' != ''">3.2.0-$(VersionSuffix)</Version>
     <Description>Adapter for xunit for using NHamcrest library</Description>
-    <Authors>Graham Hay, Algirdas Lašas</Authors>
+    <Authors>Graham Hay, Algirdas Lašas, Constantin Tews</Authors>
     <PackageLicenseUrl>https://github.com/nhamcrest/NHamcrest/blob/master/LICENCE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/nhamcrest/NHamcrest</PackageProjectUrl>
     <PackageTags>unittesting hamcrest matcher test</PackageTags>
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
-    <FileVersion>3.1.0.0</FileVersion>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.assert" Version="2.4.2" />

--- a/src/NHamcrest/Core/StructuralComparisonMatcher.cs
+++ b/src/NHamcrest/Core/StructuralComparisonMatcher.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using NHamcrest.Extensions;
 
 namespace NHamcrest.Core
 {

--- a/src/NHamcrest/Extensions/IsExtensions.cs
+++ b/src/NHamcrest/Extensions/IsExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace NHamcrest.Extensions
+{
+    public static class IsExtensions
+    {
+        public static IMatcher<T> Is<T>(T value)
+        {
+            return NHamcrest.Is.EqualTo(value);
+        }
+    }
+}

--- a/src/NHamcrest/Extensions/TypeExtensions.cs
+++ b/src/NHamcrest/Extensions/TypeExtensions.cs
@@ -2,23 +2,22 @@
 using System.Linq;
 using System.Reflection;
 
-namespace NHamcrest.Core
+namespace NHamcrest.Extensions
 {
     internal static class TypeExtensions
     {
-        public static bool IsSimpleType(
-            this Type type)
+        public static bool IsSimpleType(this Type type)
         {
             return
                 type.GetTypeInfo().IsValueType ||
                 type.GetTypeInfo().IsPrimitive ||
                 new[] {
-                typeof(String),
-                typeof(Decimal),
-                typeof(DateTime),
-                typeof(DateTimeOffset),
-                typeof(TimeSpan),
-                typeof(Guid)
+            typeof(string),
+            typeof(decimal),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(TimeSpan),
+            typeof(Guid)
             }.Contains(type) ||
                 Convert.GetTypeCode(type) != TypeCode.Object;
         }

--- a/src/NHamcrest/NHamcrest.csproj
+++ b/src/NHamcrest/NHamcrest.csproj
@@ -4,18 +4,16 @@
     <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Copyright>Copyright © 2022</Copyright>
-    <Version Condition="'$(VersionSuffix)' == ''">3.1.0</Version>
-    <Version Condition="'$(VersionSuffix)' != ''">3.1.0-$(VersionSuffix)</Version>
+    <Copyright>Copyright © 2023</Copyright>
+    <Version Condition="'$(VersionSuffix)' == ''">3.2.0</Version>
+    <Version Condition="'$(VersionSuffix)' != ''">3.2.0-$(VersionSuffix)</Version>
     <Description>.NET port of Hamcrest, a matcher library with some extra matchers</Description>
-    <Authors>Graham Hay, Algirdas Lašas</Authors>
-    <Company />
-    <Product />
+    <Authors>Graham Hay, Algirdas Lašas, Constantin Tews</Authors>
     <PackageLicenseUrl>https://github.com/nhamcrest/NHamcrest/blob/master/LICENCE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/nhamcrest/NHamcrest</PackageProjectUrl>
     <PackageTags>unittesting hamcrest matcher test</PackageTags>
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
-    <FileVersion>3.1.0.0</FileVersion>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/src/NHamcrest/app.config
+++ b/src/NHamcrest/app.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0"?>
-<configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>


### PR DESCRIPTION
- Extend `XUnit.Assert.That()` with user messages. 
- Add IsExtensions for `Assert.That(value, Is(otherValue))`.
- Update dependencies.

Closes #18 