### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/NHamcrest.sln
+++ b/NHamcrest.sln
@@ -1,23 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34003.232
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NUnit", "NUnit", "{9985B589-EC67-4FE7-83A1-3A68959CAAAC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "XUnit", "XUnit", "{0EE42F24-2D10-425F-814F-F2C67431C5B7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHamcrest.NUnit", "src\NHamcrest.NUnit\NHamcrest.NUnit.csproj", "{ED5F34C9-D815-46CD-BAC2-AC62A795894B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHamcrest.NUnit", "src\NHamcrest.NUnit\NHamcrest.NUnit.csproj", "{ED5F34C9-D815-46CD-BAC2-AC62A795894B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHamcrest.NUnit.Examples", "src\NHamcrest.NUnit.Examples\NHamcrest.NUnit.Examples.csproj", "{3047BC0C-DD71-4EC8-9835-15B9A41B2C62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHamcrest.NUnit.Examples", "src\NHamcrest.NUnit.Examples\NHamcrest.NUnit.Examples.csproj", "{3047BC0C-DD71-4EC8-9835-15B9A41B2C62}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHamcrest.XUnit", "src\NHamcrest.XUnit\NHamcrest.XUnit.csproj", "{235F5147-DCDC-439C-9220-DF2E5FB23F66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHamcrest.XUnit", "src\NHamcrest.XUnit\NHamcrest.XUnit.csproj", "{235F5147-DCDC-439C-9220-DF2E5FB23F66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHamcrest.XUnit.Examples", "src\NHamcrest.XUnit.Examples\NHamcrest.XUnit.Examples.csproj", "{FB567185-A872-4D8E-A4C5-CC3D4430D7DF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHamcrest.XUnit.Examples", "src\NHamcrest.XUnit.Examples\NHamcrest.XUnit.Examples.csproj", "{FB567185-A872-4D8E-A4C5-CC3D4430D7DF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHamcrest", "src\NHamcrest\NHamcrest.csproj", "{BF7E7EB3-0C15-4F55-85F9-B2A7564D98D4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHamcrest", "src\NHamcrest\NHamcrest.csproj", "{BF7E7EB3-0C15-4F55-85F9-B2A7564D98D4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHamcrest.Tests", "src\NHamcrest.Tests\NHamcrest.Tests.csproj", "{368D7391-0C63-4F48-8D8C-3942E0693B92}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHamcrest.Tests", "src\NHamcrest.Tests\NHamcrest.Tests.csproj", "{368D7391-0C63-4F48-8D8C-3942E0693B92}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6554B7FF-2FE4-44AC-A33A-730FC30A0728}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/NHamcrest.NUnit.Examples/NHamcrest.NUnit.Examples.csproj
+++ b/src/NHamcrest.NUnit.Examples/NHamcrest.NUnit.Examples.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/src/NHamcrest.Tests/Core/AnyOfTests.cs
+++ b/src/NHamcrest.Tests/Core/AnyOfTests.cs
@@ -1,7 +1,6 @@
+using NHamcrest.Core;
 using System;
 using System.Collections.Generic;
-
-using NHamcrest.Core;
 using Xunit;
 
 namespace NHamcrest.Tests.Core
@@ -11,7 +10,7 @@ namespace NHamcrest.Tests.Core
         private readonly CustomMatcher<string> _failingMatcher = new CustomMatcher<string>("Failing matcher", s => false);
         private readonly CustomMatcher<string> _successfulMatcher = new CustomMatcher<string>("Successful matcher", s => true);
         private readonly CustomMatcher<string> _explodingMatcher = new CustomMatcher<string>("Exploding matcher!",
-            s => { throw new Exception("BANG!!!1!. Didn't expect exploding matcher to run."); });
+            s => throw new Exception("BANG!!!1!. Didn't expect exploding matcher to run."));
 
         [Fact]
         public void Match_if_any_matchers_succeed()

--- a/src/NHamcrest.Tests/Core/CombinableMatcherTests.cs
+++ b/src/NHamcrest.Tests/Core/CombinableMatcherTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 
@@ -46,15 +45,15 @@ namespace NHamcrest.Tests.Core
             Assert.False(matcher.Matches(""));
         }
 
-		[Fact]
-		public void DescribeTo()
-		{
-			var matcher = new CombinableMatcher<string>(_failingMatcher);
-			var description = new StringDescription();
+        [Fact]
+        public void DescribeTo()
+        {
+            var matcher = new CombinableMatcher<string>(_failingMatcher);
+            var description = new StringDescription();
 
-			matcher.DescribeTo(description);
+            matcher.DescribeTo(description);
 
-			Assert.Equal("Failing matcher", description.ToString());
-		}
+            Assert.Equal("Failing matcher", description.ToString());
+        }
     }
 }

--- a/src/NHamcrest.Tests/Core/EveryTests.cs
+++ b/src/NHamcrest.Tests/Core/EveryTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;
@@ -7,13 +6,13 @@ namespace NHamcrest.Tests.Core
 {
     public class EveryTests
     {
-        private readonly IMatcher<string> _startsWithA = new CustomMatcher<string>("starts with an A", 
+        private readonly IMatcher<string> _startsWithA = new CustomMatcher<string>("starts with an A",
             s => s.StartsWith("A"));
 
         [Fact]
         public void Match_if_all_elements_match()
         {
-            var strings = new[] {"Aaaa", "Abbbb", "Acccc"};
+            var strings = new[] { "Aaaa", "Abbbb", "Acccc" };
 
             Assert.That(strings, Every.Item(_startsWithA));
         }
@@ -26,15 +25,15 @@ namespace NHamcrest.Tests.Core
             Assert.That(strings, NotEvery.Item(_startsWithA));
         }
 
-		[Fact]
-		public void Describe_to()
-		{
-			var matcher = Every.Item(_startsWithA);
-			var description = new StringDescription();
+        [Fact]
+        public void Describe_to()
+        {
+            var matcher = Every.Item(_startsWithA);
+            var description = new StringDescription();
 
-			matcher.DescribeTo(description);
+            matcher.DescribeTo(description);
 
-			Assert.That(description.ToString(), Is.EqualTo("every item starts with an A"));
-		}
+            Assert.That(description.ToString(), Is.EqualTo("every item starts with an A"));
+        }
     }
 }

--- a/src/NHamcrest.Tests/Core/IsAnythingTests.cs
+++ b/src/NHamcrest.Tests/Core/IsAnythingTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;

--- a/src/NHamcrest.Tests/Core/IsCollectionContainingTests.cs
+++ b/src/NHamcrest.Tests/Core/IsCollectionContainingTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;
@@ -10,7 +9,7 @@ namespace NHamcrest.Tests.Core
         [Fact]
         public void Has_item()
         {
-            Assert.That(new[] {"aaa", "bbb", "ccc"}, Has.Item(Is.EqualTo("aaa")));
+            Assert.That(new[] { "aaa", "bbb", "ccc" }, Has.Item(Is.EqualTo("aaa")));
         }
 
         [Fact]
@@ -30,15 +29,15 @@ namespace NHamcrest.Tests.Core
             Assert.That(description.ToString(), Is.EqualTo("a collection containing \"aaa\""));
         }
 
-		[Fact]
-		public void Describe_mismatch()
-		{
-			var matcher = Has.Item(Is.EqualTo("aaa"));
-			var description = new StringDescription();
+        [Fact]
+        public void Describe_mismatch()
+        {
+            var matcher = Has.Item(Is.EqualTo("aaa"));
+            var description = new StringDescription();
 
-			matcher.DescribeMismatch(new [] { "bbb", "ddd" }, description);
+            matcher.DescribeMismatch(new[] { "bbb", "ddd" }, description);
 
-			Assert.That(description.ToString(), Is.EqualTo("was \"bbb\", was \"ddd\""));
-		}
+            Assert.That(description.ToString(), Is.EqualTo("was \"bbb\", was \"ddd\""));
+        }
     }
 }

--- a/src/NHamcrest.Tests/Core/IsGreaterThanOrEqualToTests.cs
+++ b/src/NHamcrest.Tests/Core/IsGreaterThanOrEqualToTests.cs
@@ -1,50 +1,49 @@
-
 using NHamcrest.Core;
 using Xunit;
 using NHAssert = NHamcrest.Tests.Internal.Assert;
 
 namespace NHamcrest.Tests.Core
 {
-	public class IsGreaterThanOrEqualToTests
-	{
-		[Fact]
-		public void Match_if_greater()
-		{
-			const int five = 5;
+    public class IsGreaterThanOrEqualToTests
+    {
+        [Fact]
+        public void Match_if_greater()
+        {
+            const int five = 5;
 
-			NHAssert.That(five, Is.GreaterThanOrEqualTo(3));
-		}
+            NHAssert.That(five, Is.GreaterThanOrEqualTo(3));
+        }
 
-		[Fact]
-		public void No_match_if_less()
-		{
-			var isGreaterThanOrEqualToOne = new IsGreaterThanOrEqualTo<int>(1);
+        [Fact]
+        public void No_match_if_less()
+        {
+            var isGreaterThanOrEqualToOne = new IsGreaterThanOrEqualTo<int>(1);
 
-			var matches = isGreaterThanOrEqualToOne.Matches(0);
+            var matches = isGreaterThanOrEqualToOne.Matches(0);
 
-			Assert.False(matches);
-		}
+            Assert.False(matches);
+        }
 
-		[Fact]
-		public void Match_if_equal()
-		{
-			var isGreaterThanOrEqualToOne = new IsGreaterThanOrEqualTo<int>(1);
+        [Fact]
+        public void Match_if_equal()
+        {
+            var isGreaterThanOrEqualToOne = new IsGreaterThanOrEqualTo<int>(1);
 
-			var matches = isGreaterThanOrEqualToOne.Matches(1);
+            var matches = isGreaterThanOrEqualToOne.Matches(1);
 
-			Assert.True(matches);
-		}
+            Assert.True(matches);
+        }
 
-		[Fact]
-		public void Append_description()
-		{
-			const int six = 6;
-			var greaterThan = Is.GreaterThanOrEqualTo(six);
-			var description = new StringDescription();
+        [Fact]
+        public void Append_description()
+        {
+            const int six = 6;
+            var greaterThan = Is.GreaterThanOrEqualTo(six);
+            var description = new StringDescription();
 
-			greaterThan.DescribeTo(description);
+            greaterThan.DescribeTo(description);
 
-			Assert.Equal(description.ToString(), "greater than or equal to " + six);
-		}
-	}
+            Assert.Equal(description.ToString(), "greater than or equal to " + six);
+        }
+    }
 }

--- a/src/NHamcrest.Tests/Core/IsGreaterThanTests.cs
+++ b/src/NHamcrest.Tests/Core/IsGreaterThanTests.cs
@@ -1,50 +1,49 @@
-
 using NHamcrest.Core;
 using Xunit;
 using NHAssert = NHamcrest.Tests.Internal.Assert;
 
 namespace NHamcrest.Tests.Core
 {
-	public class IsGreaterThanTests
-	{
-		[Fact]
-		public void Match_if_greater()
-		{
-			const int five = 5;
+    public class IsGreaterThanTests
+    {
+        [Fact]
+        public void Match_if_greater()
+        {
+            const int five = 5;
 
-			NHAssert.That(five, Is.GreaterThan(3));
-		}
+            NHAssert.That(five, Is.GreaterThan(3));
+        }
 
-		[Fact]
-		public void No_match_if_not_greater()
-		{
-			var isGreaterThanOne = new IsGreaterThan<int>(1);
+        [Fact]
+        public void No_match_if_not_greater()
+        {
+            var isGreaterThanOne = new IsGreaterThan<int>(1);
 
-			var matches = isGreaterThanOne.Matches(0);
+            var matches = isGreaterThanOne.Matches(0);
 
-			Assert.False(matches);
-		}
+            Assert.False(matches);
+        }
 
-		[Fact]
-		public void No_match_if_equal()
-		{
-			var isGreaterThanOne = new IsGreaterThan<int>(1);
+        [Fact]
+        public void No_match_if_equal()
+        {
+            var isGreaterThanOne = new IsGreaterThan<int>(1);
 
-			var matches = isGreaterThanOne.Matches(1);
+            var matches = isGreaterThanOne.Matches(1);
 
-			Assert.False(matches);
-		}
+            Assert.False(matches);
+        }
 
-		[Fact]
-		public void Append_description()
-		{
-			const int six = 6;
-			var greaterThan = Is.GreaterThan(six);
-			var description = new StringDescription();
+        [Fact]
+        public void Append_description()
+        {
+            const int six = 6;
+            var greaterThan = Is.GreaterThan(six);
+            var description = new StringDescription();
 
-			greaterThan.DescribeTo(description);
+            greaterThan.DescribeTo(description);
 
-			Assert.Equal(description.ToString(), "greater than " + six);
-		}
-	}
+            Assert.Equal(description.ToString(), "greater than " + six);
+        }
+    }
 }

--- a/src/NHamcrest.Tests/Core/IsInstanceOfTests.cs
+++ b/src/NHamcrest.Tests/Core/IsInstanceOfTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;
@@ -53,7 +52,7 @@ namespace NHamcrest.Tests.Core
 
             matcher.DescribeMismatch(simonChurch, description);
 
-            const string errorMessage = "Simon Church is an instance of NHamcrest.Tests.Core.IsInstanceOfTests+SimonChurch not" + 
+            const string errorMessage = "Simon Church is an instance of NHamcrest.Tests.Core.IsInstanceOfTests+SimonChurch not" +
                                         " NHamcrest.Tests.Core.IsInstanceOfTests+ShaneLong";
             Assert.That(description.ToString(), Is.EqualTo(errorMessage));
         }

--- a/src/NHamcrest.Tests/Core/IsLessThanOrEqualToTests.cs
+++ b/src/NHamcrest.Tests/Core/IsLessThanOrEqualToTests.cs
@@ -1,50 +1,49 @@
-
 using NHamcrest.Core;
 using Xunit;
 using NHAssert = NHamcrest.Tests.Internal.Assert;
 
 namespace NHamcrest.Tests.Core
 {
-	public class IsLessThanOrEqualToTests
-	{
-		[Fact]
-		public void Match_if_less()
-		{
-			const int five = 5;
+    public class IsLessThanOrEqualToTests
+    {
+        [Fact]
+        public void Match_if_less()
+        {
+            const int five = 5;
 
-			NHAssert.That(five, Is.LessThanOrEqualTo(6));
-		}
+            NHAssert.That(five, Is.LessThanOrEqualTo(6));
+        }
 
-		[Fact]
-		public void No_match_if_not_less()
-		{
-			var lessThanOrEqualTo = new IsLessThanOrEqualTo<int>(8);
+        [Fact]
+        public void No_match_if_not_less()
+        {
+            var lessThanOrEqualTo = new IsLessThanOrEqualTo<int>(8);
 
-			var matches = lessThanOrEqualTo.Matches(9);
+            var matches = lessThanOrEqualTo.Matches(9);
 
-			Assert.False(matches);
-		}
+            Assert.False(matches);
+        }
 
-		[Fact]
-		public void Match_if_equal()
-		{
-			var isLessThanOrEqualTo = new IsLessThanOrEqualTo<int>(8);
+        [Fact]
+        public void Match_if_equal()
+        {
+            var isLessThanOrEqualTo = new IsLessThanOrEqualTo<int>(8);
 
-			var matches = isLessThanOrEqualTo.Matches(8);
+            var matches = isLessThanOrEqualTo.Matches(8);
 
-			Assert.True(matches);
-		}
+            Assert.True(matches);
+        }
 
-		[Fact]
-		public void Append_description()
-		{
-			const int six = 6;
-			var lessThan = Is.LessThanOrEqualTo(six);
-			var description = new StringDescription();
+        [Fact]
+        public void Append_description()
+        {
+            const int six = 6;
+            var lessThan = Is.LessThanOrEqualTo(six);
+            var description = new StringDescription();
 
-			lessThan.DescribeTo(description);
+            lessThan.DescribeTo(description);
 
-			Assert.Equal(description.ToString(), "less than or equal to " + six);
-		}
-	}
+            Assert.Equal(description.ToString(), "less than or equal to " + six);
+        }
+    }
 }

--- a/src/NHamcrest.Tests/Core/IsLessThanTests.cs
+++ b/src/NHamcrest.Tests/Core/IsLessThanTests.cs
@@ -1,50 +1,49 @@
-
 using NHamcrest.Core;
 using Xunit;
 using NHAssert = NHamcrest.Tests.Internal.Assert;
 
 namespace NHamcrest.Tests.Core
 {
-	public class IsLessThanTests
-	{
-		[Fact]
-		public void Match_if_less()
-		{
-			const int five = 5;
+    public class IsLessThanTests
+    {
+        [Fact]
+        public void Match_if_less()
+        {
+            const int five = 5;
 
-			NHAssert.That(five, Is.LessThan(6));
-		}
+            NHAssert.That(five, Is.LessThan(6));
+        }
 
-		[Fact]
-		public void No_match_if_not_less()
-		{
-			var isLessThanEight = new IsLessThan<int>(8);
+        [Fact]
+        public void No_match_if_not_less()
+        {
+            var isLessThanEight = new IsLessThan<int>(8);
 
-			var matches = isLessThanEight.Matches(9);
+            var matches = isLessThanEight.Matches(9);
 
-			Assert.False(matches);
-		}
+            Assert.False(matches);
+        }
 
-		[Fact]
-		public void No_match_if_equal()
-		{
-			var isLessThanEight = new IsLessThan<int>(8);
+        [Fact]
+        public void No_match_if_equal()
+        {
+            var isLessThanEight = new IsLessThan<int>(8);
 
-			var matches = isLessThanEight.Matches(8);
+            var matches = isLessThanEight.Matches(8);
 
-			Assert.False(matches);
-		}
+            Assert.False(matches);
+        }
 
-		[Fact]
-		public void Append_description()
-		{
-			const int six = 6;
-			var lessThan = Is.LessThan(six);
-			var description = new StringDescription();
+        [Fact]
+        public void Append_description()
+        {
+            const int six = 6;
+            var lessThan = Is.LessThan(six);
+            var description = new StringDescription();
 
-			lessThan.DescribeTo(description);
+            lessThan.DescribeTo(description);
 
-			Assert.Equal(description.ToString(), "less than " + six);
-		}
-	}
+            Assert.Equal(description.ToString(), "less than " + six);
+        }
+    }
 }

--- a/src/NHamcrest.Tests/Core/IsNotTests.cs
+++ b/src/NHamcrest.Tests/Core/IsNotTests.cs
@@ -1,7 +1,5 @@
-
 using NHamcrest.Core;
 using Xunit;
-using NHamcrest.XUnit;
 using Assert = NHamcrest.XUnit.Assert;
 
 namespace NHamcrest.Tests.Core

--- a/src/NHamcrest.Tests/Core/IsNullTests.cs
+++ b/src/NHamcrest.Tests/Core/IsNullTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;

--- a/src/NHamcrest.Tests/Core/IsSameTests.cs
+++ b/src/NHamcrest.Tests/Core/IsSameTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;
@@ -11,7 +10,7 @@ namespace NHamcrest.Tests.Core
         public void Match_if_same_object()
         {
             var a = new A();
-            
+
             Assert.That(a, Is.SameAs(a));
         }
 

--- a/src/NHamcrest.Tests/Core/StringContainsTests.cs
+++ b/src/NHamcrest.Tests/Core/StringContainsTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;

--- a/src/NHamcrest.Tests/Core/StringStartsWithTests.cs
+++ b/src/NHamcrest.Tests/Core/StringStartsWithTests.cs
@@ -1,4 +1,3 @@
-
 using NHamcrest.Core;
 using Xunit;
 using Assert = NHamcrest.Tests.Internal.Assert;

--- a/src/NHamcrest.Tests/Core/ThrowsTests.cs
+++ b/src/NHamcrest.Tests/Core/ThrowsTests.cs
@@ -1,108 +1,109 @@
-using System;
 using NHamcrest.Core;
+using System;
 using Xunit;
 using NHAssert = NHamcrest.Tests.Internal.Assert;
 
 namespace NHamcrest.Tests.Core
 {
-	public class ThrowsTests
-	{
-		[Fact]
-		public void Describe_matcher()
-		{
-			var matcher = new ThrowsMatcher<ArgumentNullException>();
-			var description = new StringDescription();
+    public class ThrowsTests
+    {
+        [Fact]
+        public void Describe_matcher()
+        {
+            var matcher = new ThrowsMatcher<ArgumentNullException>();
+            var description = new StringDescription();
 
-			matcher.DescribeTo(description);
+            matcher.DescribeTo(description);
 
-			NHAssert.That(description.ToString(), Is.EqualTo("the block to throw an exception of type System.ArgumentNullException"));
-		}
+            NHAssert.That(description.ToString(), Is.EqualTo("the block to throw an exception of type System.ArgumentNullException"));
+        }
 
-		[Fact]
-		public void Match_if_action_throws_expected_exception()
-		{
-			NHAssert.That(() => DoIt(), Throws.An<ArgumentNullException>());
-		}
+        [Fact]
+        public void Match_if_action_throws_expected_exception()
+        {
+            NHAssert.That(DoIt, Throws.An<ArgumentNullException>());
+        }
 
-		[Fact]
-		public void Match_if_action_throws_superclass_of_expected_exception()
-		{
-			NHAssert.That(() => DoIt(), Throws.An<ArgumentException>());
-		}
+        [Fact]
+        public void Match_if_action_throws_superclass_of_expected_exception()
+        {
+            NHAssert.That(DoIt, Throws.An<ArgumentException>());
+        }
 
-		[Fact]
-		public void No_match_if_action_does_not_throw()
-		{
-			var matcher = new ThrowsMatcher<ArgumentException>();
+        [Fact]
+        public void No_match_if_action_does_not_throw()
+        {
+            var matcher = new ThrowsMatcher<ArgumentException>();
 
-			var match = matcher.Matches(() => { });
+            var match = matcher.Matches(() => { });
 
-			NHAssert.That(match, Is.False());
-		}
+            NHAssert.That(match, Is.False());
+        }
 
-		[Fact]
-		public void Describe_mismatch_if_action_does_not_throw()
-		{
-			var matcher = new ThrowsMatcher<ArgumentException>();
-			var description = new StringDescription();
+        [Fact]
+        public void Describe_mismatch_if_action_does_not_throw()
+        {
+            var matcher = new ThrowsMatcher<ArgumentException>();
+            var description = new StringDescription();
 
-			matcher.DescribeMismatch(() => { }, description);
+            matcher.DescribeMismatch(() => { }, description);
 
-			NHAssert.That(description.ToString(), Is.EqualTo("no exception was thrown"));
-		}
+            NHAssert.That(description.ToString(), Is.EqualTo("no exception was thrown"));
+        }
 
-		[Fact]
-		public void No_match_if_action_throws_different_exception()
-		{
-			var matcher = new ThrowsMatcher<NullReferenceException>();
+        [Fact]
+        public void No_match_if_action_throws_different_exception()
+        {
+            var matcher = new ThrowsMatcher<NullReferenceException>();
 
-			var match = matcher.Matches(DoIt);
+            var match = matcher.Matches(DoIt);
 
-			NHAssert.That(match, Is.False());
-		}
+            NHAssert.That(match, Is.False());
+        }
 
-		[Fact]
-		public void Describe_mismatch_if_action_throws_different_exception()
-		{
-			var matcher = new ThrowsMatcher<NullReferenceException>();
-			var description = new StringDescription();
+        [Fact]
+        public void Describe_mismatch_if_action_throws_different_exception()
+        {
+            var matcher = new ThrowsMatcher<NullReferenceException>();
+            var description = new StringDescription();
 
-			matcher.DescribeMismatch(DoIt, description);
+            matcher.DescribeMismatch(DoIt, description);
 
-			NHAssert.That(description.ToString(), Starts.With("an exception of type System.ArgumentNullException was thrown"));
-		}
+            NHAssert.That(description.ToString(), Starts.With("an exception of type System.ArgumentNullException was thrown"));
+        }
 
-		[Fact]
-		public void Match_if_thrown_exception_matches_predicate()
-		{
-			NHAssert.That(DoIt, Throws.An<ArgumentNullException>().With(e => e.Message == "message" 
-				&& e.InnerException.GetType() == typeof(Exception)));
-		}
+        [Fact]
+        public void Match_if_thrown_exception_matches_predicate()
+        {
+            NHAssert.That(DoIt, Throws.An<ArgumentNullException>()
+                .With(e => e.Message == "message" && e.InnerException.GetType() == typeof(Exception)));
+        }
 
-		[Fact]
-		public void No_match_if_thrown_exception_does_not_match_predicate()
-		{
-			var matcher = new ThrowsMatcher<ArgumentNullException>().With(e => e.Message == "something else");
+        [Fact]
+        public void No_match_if_thrown_exception_does_not_match_predicate()
+        {
+            var matcher = new ThrowsMatcher<ArgumentNullException>()
+                .With(e => e.Message == "something else");
 
-			var matches = matcher.Matches(DoIt);
+            var matches = matcher.Matches(DoIt);
 
-			NHAssert.That(matches, Is.False());
-		}
+            NHAssert.That(matches, Is.False());
+        }
 
-		[Fact]
-		public void Describe_mismatch_if_thrown_exception_does_not_match_predicate()
-		{
-			var matcher = new ThrowsMatcher<ArgumentNullException>().With(e => e.Message == "something else");
-			var description = new StringDescription();
+        [Fact]
+        public void Describe_mismatch_if_thrown_exception_does_not_match_predicate()
+        {
+            var matcher = new ThrowsMatcher<ArgumentNullException>().With(e => e.Message == "something else");
+            var description = new StringDescription();
 
-			matcher.DescribeMismatch(DoIt, description);
+            matcher.DescribeMismatch(DoIt, description);
 
-			NHAssert.That(description.ToString(), Starts.With("the exception was of the correct type, but did not match the predicate"));
-		}
+            NHAssert.That(description.ToString(), Starts.With("the exception was of the correct type, but did not match the predicate"));
+        }
 
-		private void DoIt()
-		{
-			throw new ArgumentNullException("message", new Exception());
-		}
-	}
+        private void DoIt()
+        {
+            throw new ArgumentNullException("message", new Exception());
+        }
+    }
 }

--- a/src/NHamcrest.Tests/CustomMatcherTests.cs
+++ b/src/NHamcrest.Tests/CustomMatcherTests.cs
@@ -1,8 +1,7 @@
-using System;
-using Moq;
 using NHamcrest.Core;
+using NSubstitute;
+using System;
 using Xunit;
-
 
 namespace NHamcrest.Tests
 {
@@ -19,12 +18,11 @@ namespace NHamcrest.Tests
         {
             const string fixedDescription = "description";
             var matcher = new CustomMatcher<string>(fixedDescription, s => true);
-            var descriptionMock = new Mock<IDescription>();
+            var descriptionMock = Substitute.For<IDescription>();
 
-            matcher.DescribeTo(descriptionMock.Object);
+            matcher.DescribeTo(descriptionMock);
 
-            descriptionMock.Verify(d => d.AppendText(fixedDescription), Times.Once);
-            //o => o.Message("AppendText was not called on the provided IDescription."));
+            descriptionMock.Received().AppendText(fixedDescription);
         }
 
         [Fact]

--- a/src/NHamcrest.Tests/DescriptionTests.cs
+++ b/src/NHamcrest.Tests/DescriptionTests.cs
@@ -1,10 +1,8 @@
-using System;
+using NHamcrest.Core;
+using NSubstitute;
 using System.Collections.Generic;
 using System.Text;
-using Moq;
-using NHamcrest.Core;
 using Xunit;
-
 
 namespace NHamcrest.Tests
 {
@@ -28,11 +26,11 @@ namespace NHamcrest.Tests
         [Fact]
         public void AppendDescriptionOf_asks_value_to_describe_itself()
         {
-            var selfDescribingMock = new Mock<ISelfDescribing>();
+            var selfDescribingMock = Substitute.For<ISelfDescribing>();
 
-            _description.AppendDescriptionOf(selfDescribingMock.Object);
+            _description.AppendDescriptionOf(selfDescribingMock);
 
-            selfDescribingMock.Verify(sd => sd.DescribeTo(_description), Times.Once);
+            selfDescribingMock.Received().DescribeTo(_description);
         }
 
         [Fact]

--- a/src/NHamcrest.Tests/DiagnosingMatcherTests.cs
+++ b/src/NHamcrest.Tests/DiagnosingMatcherTests.cs
@@ -1,7 +1,6 @@
-using System;
 using NHamcrest.Core;
+using System;
 using Xunit;
-
 
 namespace NHamcrest.Tests
 {
@@ -48,10 +47,9 @@ namespace NHamcrest.Tests
 
             protected override bool Matches(string item, IDescription mismatchDescription)
             {
-                if (mismatchDescription.GetType() != typeof(NullDescription))
-                    throw new Exception("Expected null description");
-
-                return _match(item);
+                return mismatchDescription.GetType() != typeof(NullDescription) 
+                    ? throw new Exception("Expected null description") 
+                    : _match(item);
             }
         }
     }

--- a/src/NHamcrest.Tests/FeatureMatcherDescriptionTests.cs
+++ b/src/NHamcrest.Tests/FeatureMatcherDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using NHamcrest.Tests.TestClasses;
+﻿using NHamcrest.Tests.TestClasses;
+using System;
 using Xunit;
 
 namespace NHamcrest.Tests

--- a/src/NHamcrest.Tests/Internal/Assert.cs
+++ b/src/NHamcrest.Tests/Internal/Assert.cs
@@ -12,8 +12,10 @@ namespace NHamcrest.Tests.Internal
         private static void That<T>(T actual, IMatcher<T> matcher, string reason)
         {
             if (matcher.Matches(actual))
+            {
                 return;
-            
+            }
+
             var description = new StringDescription();
             description.AppendText(reason)
                 .AppendText("\nExpected: ")

--- a/src/NHamcrest.Tests/Internal/SelfDescribingValueTests.cs
+++ b/src/NHamcrest.Tests/Internal/SelfDescribingValueTests.cs
@@ -1,6 +1,4 @@
-using Moq;
 using Xunit;
-
 
 namespace NHamcrest.Tests.Internal
 {

--- a/src/NHamcrest.Tests/MatcherTests.cs
+++ b/src/NHamcrest.Tests/MatcherTests.cs
@@ -1,6 +1,5 @@
-
-using Moq;
 using NHamcrest.Core;
+using NSubstitute;
 using Xunit;
 
 namespace NHamcrest.Tests
@@ -10,15 +9,15 @@ namespace NHamcrest.Tests
         [Fact]
         public void DescribeMismatch_appends_item()
         {
-            var matcher = new TestMatcher();
-            var descriptionMock = new Mock<IDescription>();
-            descriptionMock.Setup(d => d.AppendText(It.IsAny<string>())).Returns(descriptionMock.Object);
             const string item = "item";
+            var matcher = new TestMatcher();
+            var descriptionMock = Substitute.For<IDescription>();
+            descriptionMock.AppendText(Arg.Any<string>()).Returns(descriptionMock);
 
-            matcher.DescribeMismatch(item, descriptionMock.Object);
+            matcher.DescribeMismatch(item, descriptionMock);
 
-            descriptionMock.Verify(d => d.AppendText("was "), Times.Once);
-            descriptionMock.Verify(d => d.AppendValue(item), Times.Once);
+            descriptionMock.AppendText("was ").Received();
+            descriptionMock.AppendValue(item).Received();
         }
 
         [Fact]

--- a/src/NHamcrest.Tests/NHamcrest.Tests.csproj
+++ b/src/NHamcrest.Tests/NHamcrest.Tests.csproj
@@ -9,14 +9,14 @@
     <Compile Remove="FeatureMatcherTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Castle.Core" Version="5.1.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Microsoft.NET.TEST.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.TEST.Sdk" Version="17.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NHamcrest.XUnit\NHamcrest.XUnit.csproj" />

--- a/src/NHamcrest.Tests/NonNullDiagnosingMatcherTests.cs
+++ b/src/NHamcrest.Tests/NonNullDiagnosingMatcherTests.cs
@@ -1,5 +1,5 @@
-using System;
 using NHamcrest.Core;
+using System;
 using Xunit;
 
 namespace NHamcrest.Tests

--- a/src/NHamcrest.Tests/NonNullMatcherTests.cs
+++ b/src/NHamcrest.Tests/NonNullMatcherTests.cs
@@ -1,6 +1,5 @@
-
-using System;
 using NHamcrest.Core;
+using System;
 using Xunit;
 
 namespace NHamcrest.Tests

--- a/src/NHamcrest.Tests/NullDescriptionTests.cs
+++ b/src/NHamcrest.Tests/NullDescriptionTests.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using NHamcrest.Core;
+using System.Collections.Generic;
 using Xunit;
 
 namespace NHamcrest.Tests

--- a/src/NHamcrest.Tests/StringDescriptionTests.cs
+++ b/src/NHamcrest.Tests/StringDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Text;
-using NHamcrest.Core;
+﻿using NHamcrest.Core;
+using System.Text;
 using Xunit;
 
 namespace NHamcrest.Tests

--- a/src/NHamcrest.Tests/StructuralComparisonMatcherFactoryFailureTest.cs
+++ b/src/NHamcrest.Tests/StructuralComparisonMatcherFactoryFailureTest.cs
@@ -31,9 +31,11 @@ namespace NHamcrest.Tests
         public void MismatchDescriptionMustBeCorrect()
         {
             var description = new StringDescription();
-            _matcher.DescribeMismatch(_matched, description);
             var expected = ExpectMismatchDescription();
+
+            _matcher.DescribeMismatch(_matched, description);
             var actual = description.ToString();
+
             Xunit.Assert.Equal(expected, actual);
         }
 
@@ -42,6 +44,7 @@ namespace NHamcrest.Tests
         {
             var expected = ExpectMatcherDescription();
             var description = new StringDescription();
+
             _matcher.DescribeTo(description);
             var actual = description.ToString();
 

--- a/src/NHamcrest.Tests/StructuralComparisonMatcherFactorySuccessTest.cs
+++ b/src/NHamcrest.Tests/StructuralComparisonMatcherFactorySuccessTest.cs
@@ -35,6 +35,7 @@ namespace NHamcrest.Tests
         {
             var expected = ExpectMatcherDescription();
             var description = new StringDescription();
+
             _matcher.DescribeTo(description);
             var actual = description.ToString();
 

--- a/src/NHamcrest.Tests/TestClasses/ClassWithArrayOfClasses.cs
+++ b/src/NHamcrest.Tests/TestClasses/ClassWithArrayOfClasses.cs
@@ -5,6 +5,7 @@ namespace NHamcrest.Tests.TestClasses
     public class ClassWithArrayOfClasses
     {
         public Guid Id { get; set; }
+
         public SimpleFlatClass[] OtherThings { get; set; }
     }
 }

--- a/src/NHamcrest.Tests/TestClasses/ClassWithDictionaryOfClasses.cs
+++ b/src/NHamcrest.Tests/TestClasses/ClassWithDictionaryOfClasses.cs
@@ -5,6 +5,7 @@ namespace NHamcrest.Tests.TestClasses
     public class ClassWithDictionaryOfClasses
     {
         public string StringValue { get; set; }
+
         public Dictionary<string, SimpleFlatClass> Map { get; set; }
     }
 }

--- a/src/NHamcrest.Tests/TestClasses/ClassWithEnumerableOfClasses.cs
+++ b/src/NHamcrest.Tests/TestClasses/ClassWithEnumerableOfClasses.cs
@@ -5,6 +5,7 @@ namespace NHamcrest.Tests.TestClasses
     public class ClassWithEnumerableOfClasses
     {
         public int IntValue { get; set; }
+
         public IEnumerable<SimpleFlatClass> OtherThings { get; set; }
     }
 }

--- a/src/NHamcrest.Tests/TestClasses/ClassWithListOfClasses.cs
+++ b/src/NHamcrest.Tests/TestClasses/ClassWithListOfClasses.cs
@@ -5,6 +5,7 @@ namespace NHamcrest.Tests.TestClasses
     public class ClassWithListOfClasses
     {
         public int IntValue { get; set; }
+
         public List<SimpleFlatClass> OtherThings { get; set; }
     }
 }

--- a/src/NHamcrest.Tests/TestClasses/DoubleNestedClass.cs
+++ b/src/NHamcrest.Tests/TestClasses/DoubleNestedClass.cs
@@ -3,6 +3,7 @@
     public class DoubleNestedClass
     {
         public float Coefficient { get; set; }
+
         public NestedClass Nested { get; set; }
     }
 }

--- a/src/NHamcrest.Tests/TestClasses/NestedClass.cs
+++ b/src/NHamcrest.Tests/TestClasses/NestedClass.cs
@@ -3,6 +3,7 @@
     public class NestedClass
     {
         public decimal SomeNumber { get; set; }
+
         public SimpleFlatClass InnerClass { get; set; }
     }
 }

--- a/src/NHamcrest.Tests/TestClasses/SimpleFlatClass.cs
+++ b/src/NHamcrest.Tests/TestClasses/SimpleFlatClass.cs
@@ -3,18 +3,21 @@
     public class SimpleFlatClass : ISimpleFlatClass
     {
         public int IntProperty { get; set; }
+
         public string StringProperty { get; set; }
     }
 
     public interface ISimpleFlatClass
     {
         int IntProperty { get; }
+
         string StringProperty { get; }
     }
 
     public class AnotherSimpleFlatClass : ISimpleFlatClass
     {
         public int IntProperty { get; set; }
+
         public string StringProperty { get; set; }
     }
 }

--- a/src/NHamcrest.XUnit.Examples/NHamcrest.XUnit.Examples.csproj
+++ b/src/NHamcrest.XUnit.Examples/NHamcrest.XUnit.Examples.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This replaces Moq with NSubstitute because of security issues in Moq's repository and the attempt to force users to be a sponsor for this project. 
(See more: https://github.com/moq/moq/issues/1372)

Also, some refactoring applied in test project. 
No new features, no new release needed.